### PR TITLE
Add requirements.txt for mybinder.org

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pymatgen


### PR DESCRIPTION
The README on https://github.com/materialsproject/mapidoc currently links to http://mybinder.org/repo/materialsproject/mapidoc to launch and run notebooks quickly without any installation. There is a stale copy of pymatgen example notebooks in that repo. I'd like to be able to remove those stale examples (deprecated imports, etc.) and just link to http://mybinder.org/repo/materialsvirtuallab/matgenb for people to try out the examples using the Materials API. For this to work, mybinder.org needs a requirements.txt in the repo root to build an appropriate Docker image.