### PR TITLE
Add dopant suggester notebook

### DIFF
--- a/notebooks/2018-11-6-Dopant suggestions using Pymatgen.ipynb
+++ b/notebooks/2018-11-6-Dopant suggestions using Pymatgen.ipynb
@@ -1,0 +1,482 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Introduction\n",
+    "\n",
+    "This notebook demonstrates how to predict likely n- and p-type dopant atoms using pymatgen. This example uses the Materials API to download the structure of interest but any `Structure` object can be used. Two methods for choosing dopants are demonstrated. The first uses a simple Shannon radii comparison, whereas the second is based on the substitution probability of two atoms calculated using the `SubstitutionPredictor` utility in pymatgen. This code requires knowledge of the oxidation state of all elements in the structure. These can be guessed using pymatgen but should be checked to ensure the validity of the results.\n",
+    "\n",
+    "\n",
+    "Written using:\n",
+    "- pymatgen==2018.10.18\n",
+    "\n",
+    "*Author: Alex Ganose (10/06/18)*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Imports we need for generating dopant suggestions\n",
+    "\n",
+    "from pymatgen.analysis.structure_prediction.substitution_probability import SubstitutionPredictor\n",
+    "from pymatgen.core.periodic_table import Specie, Element\n",
+    "from pymatgen.analysis.local_env import CrystalNN\n",
+    "\n",
+    "from pymatgen import MPRester\n",
+    "from pprint import pprint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Establish rester for accessing Materials API\n",
+    "mpr = MPRester(api_key='#########')  # INSERT YOUR OWN API KEY"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we define a variable -- `num_dopants` for how many dopants you wish to explore."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "num_dopants = 5  # number of highest probability dopants you wish to see "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Download a structure and add oxidation states\n",
+    "\n",
+    "In this section, we use the Materials API to download a structure and add information on the oxidation states of the atoms."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mp_id = 'mp-856'  # Materials Project id for rutile SnO2\n",
+    "\n",
+    "structure = mpr.get_structure_by_material_id(mp_id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The downloaded structure does not contain oxidation state information. There are two ways to add this information. The first is to specify the oxidation state of the elements manually."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "structure.add_oxidation_state_by_element({\"Sn\": 4, \"O\": -2})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Alternatively, we can use pymatgen to guess the oxidation states. If using this method you should check that the oxidation states are what you expect."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "structure.add_oxidation_state_by_guess()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's check what oxidation states pymatgen guessed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Specie O2-, Specie Sn4+]\n"
+     ]
+    }
+   ],
+   "source": [
+    "species = structure.composition.elements\n",
+    "\n",
+    "print(species)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Finding dopants by Shannon radii\n",
+    "\n",
+    "In this section, we use the known Shannon radii to predict likely dopants. We will prefer dopants which have the smallest difference in radius to the host atoms. As the Shannon radii depend on the coordination number of the site, we must first calculate the bonding in the structure. In this example we do this using the `CrystalNN` class."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cnn = CrystalNN()\n",
+    "bonded_structure = cnn.get_bonded_structure(structure)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we define a function to take a bonded structure with oxidation states and report the closest n- and p-type dopants, sorted by the difference in Shannon radii. We also define some helper functions to facilitate getting the Shannon radii for all elements in their common charge states."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "all_species = [Specie(el, oxi) for el in Element\n",
+    "               for oxi in el.common_oxidation_states]\n",
+    "\n",
+    "ROMAN = [(10, \"X\"), (9, \"IX\"), (5, \"V\"), (4, \"IV\"), (1, \"I\")]\n",
+    "\n",
+    "\n",
+    "def int_to_roman(number):\n",
+    "    \"\"\"Convert an int to a roman numeral.\"\"\"\n",
+    "    result = []\n",
+    "    for (arabic, roman) in ROMAN:\n",
+    "        (factor, number) = divmod(number, arabic)\n",
+    "        result.append(roman * factor)\n",
+    "        if number == 0:\n",
+    "            break\n",
+    "    return \"\".join(result)\n",
+    "\n",
+    "\n",
+    "def get_shannon_radii_by_cn(cn_roman, radius_to_compare=0):\n",
+    "    \"\"\"Gets all the Shannon radii for a particular coordination number.\n",
+    "    \n",
+    "    As the Shannon radii depends on charge state and coordination number,\n",
+    "    species without an entry for a particular coordination number will\n",
+    "    be skipped.\n",
+    "    \"\"\"\n",
+    "    shannon_radii = []\n",
+    "    \n",
+    "    for s in all_species:\n",
+    "        try:\n",
+    "            radius = s.get_shannon_radius(cn_roman)\n",
+    "            shannon_radii.append({\n",
+    "                'species': s, 'radius': radius,\n",
+    "                'radii_diff': radius - radius_to_compare}) \n",
+    "        except KeyError:\n",
+    "            pass\n",
+    "\n",
+    "    return shannon_radii\n",
+    "\n",
+    "\n",
+    "def get_dopant_by_shannon_radii(bonded_structure, num_dopants=5):\n",
+    "    \"\"\"Get dopant suggestions based on Shannon radii differences.\n",
+    "    \n",
+    "    Args:\n",
+    "        oxid_structure (StructureGraph): A pymatgen structure graph \n",
+    "            decorated with oxidation states.\n",
+    "        num_dopants (int): The nummber of suggestions to return for\n",
+    "            n- and p-type dopants.\n",
+    "    \"\"\"\n",
+    "    # get a series of tuples with (coordination number, specie)\n",
+    "    cn_and_species = set((bonded_structure.get_coordination_of_site(i),\n",
+    "                          bonded_structure.structure[i].specie)\n",
+    "                         for i in range(bonded_structure.structure.num_sites))\n",
+    "    \n",
+    "    cn_to_radii_map = {}\n",
+    "    possible_dopants = []\n",
+    "    \n",
+    "    for cn, species in cn_and_species:\n",
+    "        cn_roman = int_to_roman(cn)\n",
+    "        \n",
+    "        try:\n",
+    "            species_radius = species.get_shannon_radius(cn_roman)\n",
+    "        except KeyError:\n",
+    "            print(\"Shannon radius not found for {} with \"\n",
+    "                  \"coordination number {}\".format(species, cn))\n",
+    "            print(\"skipping...\")\n",
+    "            continue\n",
+    "        \n",
+    "        if cn not in cn_to_radii_map:\n",
+    "            cn_to_radii_map[cn] = get_shannon_radii_by_cn(\n",
+    "                cn_roman, radius_to_compare=species_radius)\n",
+    "        \n",
+    "        shannon_radii = cn_to_radii_map[cn]\n",
+    "\n",
+    "        possible_dopants += [{'radii_diff': p['radii_diff'],\n",
+    "                              'new_species': p['species'],\n",
+    "                              'old_species': species}\n",
+    "                             for p in shannon_radii]\n",
+    "    \n",
+    "    possible_dopants.sort(key=lambda x: abs(x['radii_diff']))\n",
+    "\n",
+    "    n_type = [pred for pred in possible_dopants\n",
+    "              if pred['new_species'].oxi_state > pred['old_species'].oxi_state]\n",
+    "    p_type = [pred for pred in possible_dopants\n",
+    "              if pred['new_species'].oxi_state < pred['old_species'].oxi_state]\n",
+    "    \n",
+    "    return {'n_type': n_type[:num_dopants], 'p_type': p_type[:num_dopants]}       "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's run the function on our bonded structure:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'n_type': [{'new_species': Specie U6+,\n",
+      "             'old_species': Specie Sn4+,\n",
+      "             'radii_diff': 0.040000000000000036},\n",
+      "            {'new_species': Specie Nb5+,\n",
+      "             'old_species': Specie Sn4+,\n",
+      "             'radii_diff': -0.04999999999999993},\n",
+      "            {'new_species': Specie Ta5+,\n",
+      "             'old_species': Specie Sn4+,\n",
+      "             'radii_diff': -0.04999999999999993},\n",
+      "            {'new_species': Specie F-,\n",
+      "             'old_species': Specie O2-,\n",
+      "             'radii_diff': -0.06000000000000005},\n",
+      "            {'new_species': Specie Np5+,\n",
+      "             'old_species': Specie Sn4+,\n",
+      "             'radii_diff': 0.06000000000000005}],\n",
+      " 'p_type': [{'new_species': Specie Ni2+,\n",
+      "             'old_species': Specie Sn4+,\n",
+      "             'radii_diff': 0.0},\n",
+      "            {'new_species': Specie Ru3+,\n",
+      "             'old_species': Specie Sn4+,\n",
+      "             'radii_diff': -0.009999999999999898},\n",
+      "            {'new_species': Specie Ir3+,\n",
+      "             'old_species': Specie Sn4+,\n",
+      "             'radii_diff': -0.009999999999999898},\n",
+      "            {'new_species': Specie Rh3+,\n",
+      "             'old_species': Specie Sn4+,\n",
+      "             'radii_diff': -0.02499999999999991},\n",
+      "            {'new_species': Specie Mg2+,\n",
+      "             'old_species': Specie Sn4+,\n",
+      "             'radii_diff': 0.030000000000000027}]}\n"
+     ]
+    }
+   ],
+   "source": [
+    "dopants = get_dopant_by_shannon_radii(bonded_structure, num_dopants=num_dopants)\n",
+    "\n",
+    "pprint(dopants)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The most favoured n-type dopant is U on a Sn site. Unfortunately, this is not a sustainable or safe choice of dopant. The most common industrial n-type dopant for SnO2 is fluorine. While F is present in our list of suggested dopants, it found way down at suggestion number 4.\n",
+    "\n",
+    "Another limitation of the Shannon radii approach to choosing dopants is that the radii depend on both the coordination number and charge state. For many elements, the radii for charge states and coordination numbers have not been tabulated, meaning this approach is incomplete.\n",
+    "\n",
+    "Instead we should use a more robust approach to determine possible dopants. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Finding dopants by substitution probability\n",
+    "\n",
+    "In this section, we use the `SubstitutionPredictor` to predict likely dopants substitutions using a data-mined approach from ICSD data. Based on the species in the structure, we get a list of which species are likely to substitute in but have different charge states. The substitution prediction methodology is presented in: \n",
+    "*Hautier, G., Fischer, C., Ehrlacher, V., Jain, A., and Ceder, G. (2011) Data Mined Ionic Substitutions for the Discovery of New Compounds. Inorganic Chemistry, 50(2), 656-663. doi:10.1021/ic102031h*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here, we define a variable -- `threshold` for the threshold probability in making substitution/structure predictions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "threshold = 0.001  # probability threshold for substitution/structure predictions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we define a function to filter the predicted substitutions by their charge states. Based on this, we report those substitutions that will be n- or p-type dopants."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sp = SubstitutionPredictor(threshold=threshold)\n",
+    "\n",
+    "\n",
+    "def get_dopant_suggestions(oxid_structure, num_dopants=5, threshold=0.001):\n",
+    "    \"\"\"Get dopant suggestions based on substitution probabilities.\n",
+    "    \n",
+    "    Args:\n",
+    "        oxid_structure (Structure): A pymatgen structure decorated with\n",
+    "            oxidation states.\n",
+    "        num_dopants (int): The nummber of suggestions to return for\n",
+    "            n- and p-type dopants.\n",
+    "        threshold (float): Probability threshold for substitutions.\n",
+    "    \"\"\"\n",
+    "    subs = [sp.list_prediction([s]) for s in structure.composition.elements]\n",
+    "    subs = [{'probability': pred['probability'],\n",
+    "             'new_species': list(pred['substitutions'].keys())[0],\n",
+    "             'old_species': list(pred['substitutions'].values())[0]} \n",
+    "            for species_preds in subs for pred in species_preds]\n",
+    "    subs.sort(key=lambda x: x['probability'], reverse=True)\n",
+    "    \n",
+    "    n_type = [pred for pred in subs\n",
+    "              if pred['new_species'].oxi_state > pred['old_species'].oxi_state]\n",
+    "    p_type = [pred for pred in subs\n",
+    "              if pred['new_species'].oxi_state < pred['old_species'].oxi_state] \n",
+    "    \n",
+    "    return {'n_type': n_type[:num_dopants], 'p_type': p_type[:num_dopants]}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's run the function on the structure we downloaded earlier:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:root:11 substitutions found\n",
+      "INFO:root:87 substitutions found\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'n_type': [{'new_species': Specie F-,\n",
+      "             'old_species': Specie O2-,\n",
+      "             'probability': 0.06692682583342519},\n",
+      "            {'new_species': Specie Cl-,\n",
+      "             'old_species': Specie O2-,\n",
+      "             'probability': 0.0210226382884322},\n",
+      "            {'new_species': Specie Ta5+,\n",
+      "             'old_species': Specie Sn4+,\n",
+      "             'probability': 0.019486221245908524},\n",
+      "            {'new_species': Specie Sb5+,\n",
+      "             'old_species': Specie Sn4+,\n",
+      "             'probability': 0.010380692735493769},\n",
+      "            {'new_species': Specie Nb5+,\n",
+      "             'old_species': Specie Sn4+,\n",
+      "             'probability': 0.009988531781437165}],\n",
+      " 'p_type': [{'new_species': Specie Co2+,\n",
+      "             'old_species': Specie Sn4+,\n",
+      "             'probability': 0.023398867249112963},\n",
+      "            {'new_species': Specie Cd2+,\n",
+      "             'old_species': Specie Sn4+,\n",
+      "             'probability': 0.022644061067779372},\n",
+      "            {'new_species': Specie Li+,\n",
+      "             'old_species': Specie Sn4+,\n",
+      "             'probability': 0.022394101830147086},\n",
+      "            {'new_species': Specie Fe2+,\n",
+      "             'old_species': Specie Sn4+,\n",
+      "             'probability': 0.020971777662831415},\n",
+      "            {'new_species': Specie Ca2+,\n",
+      "             'old_species': Specie Sn4+,\n",
+      "             'probability': 0.019487195581329005}]}\n"
+     ]
+    }
+   ],
+   "source": [
+    "dopants = get_dopant_suggestions(structure, num_dopants=num_dopants, threshold=threshold)\n",
+    "\n",
+    "pprint(dopants)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We get a list of potential dopants sorted by their substitution probability. The most likely n-type dopant is F on a O site. Fluorine doped SnO2 (FTO) is one of the most widely used transparent conducting oxides, therefore validating this approach."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/2018-11-6-Dopant suggestions using Pymatgen.ipynb
+++ b/notebooks/2018-11-6-Dopant suggestions using Pymatgen.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "\n",
     "Written using:\n",
-    "- pymatgen==2018.10.18\n",
+    "- pymatgen==2018.11.Y\n",
     "\n",
     "*Author: Alex Ganose (10/06/18)*"
    ]
@@ -23,8 +23,8 @@
    "source": [
     "# Imports we need for generating dopant suggestions\n",
     "\n",
-    "from pymatgen.analysis.structure_prediction.substitution_probability import SubstitutionPredictor\n",
-    "from pymatgen.core.periodic_table import Specie, Element\n",
+    "from pymatgen.analysis.structure_prediction.dopant_predictor import \\\n",
+    "    get_dopants_from_shannon_radii, get_dopants_from_substitution_probabilities\n",
     "from pymatgen.analysis.local_env import CrystalNN\n",
     "\n",
     "from pymatgen import MPRester\n",
@@ -38,7 +38,10 @@
    "outputs": [],
    "source": [
     "# Establish rester for accessing Materials API\n",
-    "mpr = MPRester(api_key='#########')  # INSERT YOUR OWN API KEY"
+    "\n",
+    "api_key = None  # INSERT YOUR OWN API KEY\n",
+    "\n",
+    "mpr = MPRester(api_key=api_key)  "
    ]
   },
   {
@@ -141,7 +144,7 @@
    "source": [
     "## Finding dopants by Shannon radii\n",
     "\n",
-    "In this section, we use the known Shannon radii to predict likely dopants. We will prefer dopants which have the smallest difference in radius to the host atoms. As the Shannon radii depend on the coordination number of the site, we must first calculate the bonding in the structure. In this example we do this using the `CrystalNN` class."
+    "In this section, we use the known Shannon radii to predict likely dopants. We will prefer dopants which have the smallest difference in radius to the host atoms. As the Shannon radii depend on the coordination number of the site, we must first calculate the bonding in the structure. In this example, we do this using the `CrystalNN` class."
    ]
   },
   {
@@ -158,153 +161,53 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next, we define a function to take a bonded structure with oxidation states and report the closest n- and p-type dopants, sorted by the difference in Shannon radii. We also define some helper functions to facilitate getting the Shannon radii for all elements in their common charge states."
+    "Pymatgen has a function to take a bonded structure with oxidation states and report the closest n- and p-type dopants, sorted by the difference in Shannon radii. Let's run this on our bonded structure:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
    "metadata": {},
-   "outputs": [],
-   "source": [
-    "all_species = [Specie(el, oxi) for el in Element\n",
-    "               for oxi in el.common_oxidation_states]\n",
-    "\n",
-    "ROMAN = [(10, \"X\"), (9, \"IX\"), (5, \"V\"), (4, \"IV\"), (1, \"I\")]\n",
-    "\n",
-    "\n",
-    "def int_to_roman(number):\n",
-    "    \"\"\"Convert an int to a roman numeral.\"\"\"\n",
-    "    result = []\n",
-    "    for (arabic, roman) in ROMAN:\n",
-    "        (factor, number) = divmod(number, arabic)\n",
-    "        result.append(roman * factor)\n",
-    "        if number == 0:\n",
-    "            break\n",
-    "    return \"\".join(result)\n",
-    "\n",
-    "\n",
-    "def get_shannon_radii_by_cn(cn_roman, radius_to_compare=0):\n",
-    "    \"\"\"Gets all the Shannon radii for a particular coordination number.\n",
-    "    \n",
-    "    As the Shannon radii depends on charge state and coordination number,\n",
-    "    species without an entry for a particular coordination number will\n",
-    "    be skipped.\n",
-    "    \"\"\"\n",
-    "    shannon_radii = []\n",
-    "    \n",
-    "    for s in all_species:\n",
-    "        try:\n",
-    "            radius = s.get_shannon_radius(cn_roman)\n",
-    "            shannon_radii.append({\n",
-    "                'species': s, 'radius': radius,\n",
-    "                'radii_diff': radius - radius_to_compare}) \n",
-    "        except KeyError:\n",
-    "            pass\n",
-    "\n",
-    "    return shannon_radii\n",
-    "\n",
-    "\n",
-    "def get_dopant_by_shannon_radii(bonded_structure, num_dopants=5):\n",
-    "    \"\"\"Get dopant suggestions based on Shannon radii differences.\n",
-    "    \n",
-    "    Args:\n",
-    "        oxid_structure (StructureGraph): A pymatgen structure graph \n",
-    "            decorated with oxidation states.\n",
-    "        num_dopants (int): The nummber of suggestions to return for\n",
-    "            n- and p-type dopants.\n",
-    "    \"\"\"\n",
-    "    # get a series of tuples with (coordination number, specie)\n",
-    "    cn_and_species = set((bonded_structure.get_coordination_of_site(i),\n",
-    "                          bonded_structure.structure[i].specie)\n",
-    "                         for i in range(bonded_structure.structure.num_sites))\n",
-    "    \n",
-    "    cn_to_radii_map = {}\n",
-    "    possible_dopants = []\n",
-    "    \n",
-    "    for cn, species in cn_and_species:\n",
-    "        cn_roman = int_to_roman(cn)\n",
-    "        \n",
-    "        try:\n",
-    "            species_radius = species.get_shannon_radius(cn_roman)\n",
-    "        except KeyError:\n",
-    "            print(\"Shannon radius not found for {} with \"\n",
-    "                  \"coordination number {}\".format(species, cn))\n",
-    "            print(\"skipping...\")\n",
-    "            continue\n",
-    "        \n",
-    "        if cn not in cn_to_radii_map:\n",
-    "            cn_to_radii_map[cn] = get_shannon_radii_by_cn(\n",
-    "                cn_roman, radius_to_compare=species_radius)\n",
-    "        \n",
-    "        shannon_radii = cn_to_radii_map[cn]\n",
-    "\n",
-    "        possible_dopants += [{'radii_diff': p['radii_diff'],\n",
-    "                              'new_species': p['species'],\n",
-    "                              'old_species': species}\n",
-    "                             for p in shannon_radii]\n",
-    "    \n",
-    "    possible_dopants.sort(key=lambda x: abs(x['radii_diff']))\n",
-    "\n",
-    "    n_type = [pred for pred in possible_dopants\n",
-    "              if pred['new_species'].oxi_state > pred['old_species'].oxi_state]\n",
-    "    p_type = [pred for pred in possible_dopants\n",
-    "              if pred['new_species'].oxi_state < pred['old_species'].oxi_state]\n",
-    "    \n",
-    "    return {'n_type': n_type[:num_dopants], 'p_type': p_type[:num_dopants]}       "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now let's run the function on our bonded structure:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'n_type': [{'new_species': Specie U6+,\n",
-      "             'old_species': Specie Sn4+,\n",
+      "{'n_type': [{'dopant_species': Specie U6+,\n",
+      "             'original_species': Specie Sn4+,\n",
       "             'radii_diff': 0.040000000000000036},\n",
-      "            {'new_species': Specie Nb5+,\n",
-      "             'old_species': Specie Sn4+,\n",
+      "            {'dopant_species': Specie Nb5+,\n",
+      "             'original_species': Specie Sn4+,\n",
       "             'radii_diff': -0.04999999999999993},\n",
-      "            {'new_species': Specie Ta5+,\n",
-      "             'old_species': Specie Sn4+,\n",
+      "            {'dopant_species': Specie Ta5+,\n",
+      "             'original_species': Specie Sn4+,\n",
       "             'radii_diff': -0.04999999999999993},\n",
-      "            {'new_species': Specie F-,\n",
-      "             'old_species': Specie O2-,\n",
+      "            {'dopant_species': Specie F-,\n",
+      "             'original_species': Specie O2-,\n",
       "             'radii_diff': -0.06000000000000005},\n",
-      "            {'new_species': Specie Np5+,\n",
-      "             'old_species': Specie Sn4+,\n",
+      "            {'dopant_species': Specie Np5+,\n",
+      "             'original_species': Specie Sn4+,\n",
       "             'radii_diff': 0.06000000000000005}],\n",
-      " 'p_type': [{'new_species': Specie Ni2+,\n",
-      "             'old_species': Specie Sn4+,\n",
+      " 'p_type': [{'dopant_species': Specie Ni2+,\n",
+      "             'original_species': Specie Sn4+,\n",
       "             'radii_diff': 0.0},\n",
-      "            {'new_species': Specie Ru3+,\n",
-      "             'old_species': Specie Sn4+,\n",
+      "            {'dopant_species': Specie Ru3+,\n",
+      "             'original_species': Specie Sn4+,\n",
       "             'radii_diff': -0.009999999999999898},\n",
-      "            {'new_species': Specie Ir3+,\n",
-      "             'old_species': Specie Sn4+,\n",
+      "            {'dopant_species': Specie Ir3+,\n",
+      "             'original_species': Specie Sn4+,\n",
       "             'radii_diff': -0.009999999999999898},\n",
-      "            {'new_species': Specie Rh3+,\n",
-      "             'old_species': Specie Sn4+,\n",
+      "            {'dopant_species': Specie Rh3+,\n",
+      "             'original_species': Specie Sn4+,\n",
       "             'radii_diff': -0.02499999999999991},\n",
-      "            {'new_species': Specie Mg2+,\n",
-      "             'old_species': Specie Sn4+,\n",
+      "            {'dopant_species': Specie Mg2+,\n",
+      "             'original_species': Specie Sn4+,\n",
       "             'radii_diff': 0.030000000000000027}]}\n"
      ]
     }
    ],
    "source": [
-    "dopants = get_dopant_by_shannon_radii(bonded_structure, num_dopants=num_dopants)\n",
+    "dopants = get_dopants_from_shannon_radii(bonded_structure, num_dopants=num_dopants)\n",
     "\n",
     "pprint(dopants)"
    ]
@@ -315,7 +218,7 @@
    "source": [
     "The most favoured n-type dopant is U on a Sn site. Unfortunately, this is not a sustainable or safe choice of dopant. The most common industrial n-type dopant for SnO2 is fluorine. While F is present in our list of suggested dopants, it found way down at suggestion number 4.\n",
     "\n",
-    "Another limitation of the Shannon radii approach to choosing dopants is that the radii depend on both the coordination number and charge state. For many elements, the radii for charge states and coordination numbers have not been tabulated, meaning this approach is incomplete.\n",
+    "Another limitation of the Shannon radii approach to choosing dopants is that the radii depend on both the coordination number and charge state. For many elements, the radii for many charge state/coordination number combinations have not been tabulated, meaning this approach is incomplete.\n",
     "\n",
     "Instead we should use a more robust approach to determine possible dopants. "
    ]
@@ -326,7 +229,7 @@
    "source": [
     "## Finding dopants by substitution probability\n",
     "\n",
-    "In this section, we use the `SubstitutionPredictor` to predict likely dopants substitutions using a data-mined approach from ICSD data. Based on the species in the structure, we get a list of which species are likely to substitute in but have different charge states. The substitution prediction methodology is presented in: \n",
+    "In this section, we use the statistics provided by `SubstitutionPredictor` to predict likely dopants substitutions using a data-mined approach from ICSD data. Based on the species in the structure, we get a list of which species are likely to substitute in but have different charge states. The substitution prediction methodology is presented in: \n",
     "*Hautier, G., Fischer, C., Ehrlacher, V., Jain, A., and Ceder, G. (2011) Data Mined Ionic Substitutions for the Discovery of New Compounds. Inorganic Chemistry, 50(2), 656-663. doi:10.1021/ic102031h*"
    ]
   },
@@ -339,7 +242,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -350,102 +253,62 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next, we define a function to filter the predicted substitutions by their charge states. Based on this, we report those substitutions that will be n- or p-type dopants."
+    "Pymatgen provides a function to filter the predicted substitutions by their charge states and return a list of n- and p-type dopants. Let's run the function on the structure we downloaded earlier:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sp = SubstitutionPredictor(threshold=threshold)\n",
-    "\n",
-    "\n",
-    "def get_dopant_suggestions(oxid_structure, num_dopants=5, threshold=0.001):\n",
-    "    \"\"\"Get dopant suggestions based on substitution probabilities.\n",
-    "    \n",
-    "    Args:\n",
-    "        oxid_structure (Structure): A pymatgen structure decorated with\n",
-    "            oxidation states.\n",
-    "        num_dopants (int): The nummber of suggestions to return for\n",
-    "            n- and p-type dopants.\n",
-    "        threshold (float): Probability threshold for substitutions.\n",
-    "    \"\"\"\n",
-    "    subs = [sp.list_prediction([s]) for s in structure.composition.elements]\n",
-    "    subs = [{'probability': pred['probability'],\n",
-    "             'new_species': list(pred['substitutions'].keys())[0],\n",
-    "             'old_species': list(pred['substitutions'].values())[0]} \n",
-    "            for species_preds in subs for pred in species_preds]\n",
-    "    subs.sort(key=lambda x: x['probability'], reverse=True)\n",
-    "    \n",
-    "    n_type = [pred for pred in subs\n",
-    "              if pred['new_species'].oxi_state > pred['old_species'].oxi_state]\n",
-    "    p_type = [pred for pred in subs\n",
-    "              if pred['new_species'].oxi_state < pred['old_species'].oxi_state] \n",
-    "    \n",
-    "    return {'n_type': n_type[:num_dopants], 'p_type': p_type[:num_dopants]}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now let's run the function on the structure we downloaded earlier:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:root:11 substitutions found\n",
-      "INFO:root:87 substitutions found\n"
+      "INFO:root:87 substitutions found\n",
+      "INFO:root:11 substitutions found\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'n_type': [{'new_species': Specie F-,\n",
-      "             'old_species': Specie O2-,\n",
-      "             'probability': 0.06692682583342519},\n",
-      "            {'new_species': Specie Cl-,\n",
-      "             'old_species': Specie O2-,\n",
-      "             'probability': 0.0210226382884322},\n",
-      "            {'new_species': Specie Ta5+,\n",
-      "             'old_species': Specie Sn4+,\n",
-      "             'probability': 0.019486221245908524},\n",
-      "            {'new_species': Specie Sb5+,\n",
-      "             'old_species': Specie Sn4+,\n",
-      "             'probability': 0.010380692735493769},\n",
-      "            {'new_species': Specie Nb5+,\n",
-      "             'old_species': Specie Sn4+,\n",
-      "             'probability': 0.009988531781437165}],\n",
-      " 'p_type': [{'new_species': Specie Co2+,\n",
-      "             'old_species': Specie Sn4+,\n",
-      "             'probability': 0.023398867249112963},\n",
-      "            {'new_species': Specie Cd2+,\n",
-      "             'old_species': Specie Sn4+,\n",
-      "             'probability': 0.022644061067779372},\n",
-      "            {'new_species': Specie Li+,\n",
-      "             'old_species': Specie Sn4+,\n",
-      "             'probability': 0.022394101830147086},\n",
-      "            {'new_species': Specie Fe2+,\n",
-      "             'old_species': Specie Sn4+,\n",
-      "             'probability': 0.020971777662831415},\n",
-      "            {'new_species': Specie Ca2+,\n",
-      "             'old_species': Specie Sn4+,\n",
-      "             'probability': 0.019487195581329005}]}\n"
+      "{'n_type': [{'dopant_species': Specie F-,\n",
+      "             'original_species': Specie O2-,\n",
+      "             'probability': 0.06692682583342485},\n",
+      "            {'dopant_species': Specie Cl-,\n",
+      "             'original_species': Specie O2-,\n",
+      "             'probability': 0.021022638288432097},\n",
+      "            {'dopant_species': Specie Ta5+,\n",
+      "             'original_species': Specie Sn4+,\n",
+      "             'probability': 0.01948622124590853},\n",
+      "            {'dopant_species': Specie Sb5+,\n",
+      "             'original_species': Specie Sn4+,\n",
+      "             'probability': 0.010380692735493774},\n",
+      "            {'dopant_species': Specie Nb5+,\n",
+      "             'original_species': Specie Sn4+,\n",
+      "             'probability': 0.00998853178143717}],\n",
+      " 'p_type': [{'dopant_species': Specie Co2+,\n",
+      "             'original_species': Specie Sn4+,\n",
+      "             'probability': 0.023398867249112974},\n",
+      "            {'dopant_species': Specie Cd2+,\n",
+      "             'original_species': Specie Sn4+,\n",
+      "             'probability': 0.022644061067779383},\n",
+      "            {'dopant_species': Specie Li+,\n",
+      "             'original_species': Specie Sn4+,\n",
+      "             'probability': 0.022394101830147096},\n",
+      "            {'dopant_species': Specie Fe2+,\n",
+      "             'original_species': Specie Sn4+,\n",
+      "             'probability': 0.020971777662831426},\n",
+      "            {'dopant_species': Specie Ca2+,\n",
+      "             'original_species': Specie Sn4+,\n",
+      "             'probability': 0.019487195581329015}]}\n"
      ]
     }
    ],
    "source": [
-    "dopants = get_dopant_suggestions(structure, num_dopants=num_dopants, threshold=threshold)\n",
+    "dopants = get_dopants_from_substitution_probabilities(\n",
+    "    structure, num_dopants=num_dopants, threshold=threshold)\n",
     "\n",
     "pprint(dopants)"
    ]
@@ -454,7 +317,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We get a list of potential dopants sorted by their substitution probability. The most likely n-type dopant is F on a O site. Fluorine doped SnO2 (FTO) is one of the most widely used transparent conducting oxides, therefore validating this approach."
+    "The function returns a list of potential dopants sorted by their substitution probability. The most likely n-type dopant is F on a O site. Fluorine doped SnO2 (FTO) is one of the most widely used transparent conducting oxides, therefore validating this approach."
    ]
   }
  ],


### PR DESCRIPTION
Based on discussions in the MP design meetings, I've implemented a notebook to help suggest substitutional dopants based on a crystal structure.

The notebook details two methods of predicting dopants:
- The first is based on differences in Shannon radii (which I show does not work well).
- The second is based on the substitutional probabilities available from `SubstitutionPredictor`.

The notebook goes beyond the functionality in `SubstitutionPredictor` as it sorts the dopants into n- and p-type dopants.

I've marked this PR as WIP as I had to write a bit of extra code to get these examples to work. 

@shyuep or @computron: I'm interested to hear whether you think I should just add these methods (with better docs and tests) to pymatgen itself or leave them in the notebook?

You can see the notebook here:

https://github.com/materialsvirtuallab/matgenb/blob/898f47f7c6210fbc825d0d8d02c2aeb142135020/notebooks/2018-11-6-Dopant%20suggestions%20using%20Pymatgen.ipynb