### PR TITLE
Adding binderhub support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+Try out notebooks online without installation using Binderhub.
+
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/materialsvirtuallab/matgenb/master)
+
 Visit the [Github Pages](http://matgenb.materialsvirtuallab.org) for a nicely formatted HTML page and notebook search functionality.
 
 # Introduction


### PR DESCRIPTION
Adding binder support allows notebooks to be tried out before installation anything. Was just browsing through repository and saw how easy it would be to allow users to try out pymatgen without installation. Perfect use case for binderhub.